### PR TITLE
Switch to Open JDK 8 to fix container build

### DIFF
--- a/mid-server/Dockerfile
+++ b/mid-server/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get -q update && apt-get install -qy unzip \
   software-properties-common \
   wget && \
   apt-get upgrade -y && \
-  add-apt-repository ppa:webupd8team/java -y && \
+  add-apt-repository ppa:openjdk-r/ppa -y && \
   apt-get update && \
   echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-  apt-get install -y oracle-java8-installer && \
+  apt-get install -y openjdk-8-jdk && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/mid-server/Dockerfile_london
+++ b/mid-server/Dockerfile_london
@@ -12,10 +12,10 @@ RUN apt-get -q update && apt-get install -qy unzip \
     wget && \
     apt-get upgrade -y && \
     apt-get install -y  software-properties-common && \
-    add-apt-repository ppa:webupd8team/java -y && \
+    add-apt-repository ppa:openjdk-r/ppa -y && \
     apt-get update && \
     echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get install -y oracle-java8-installer && \
+    apt-get install -y openjdk-8-jdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     wget --no-check-certificate \


### PR DESCRIPTION
Previous PPA and oracle-java-8 package no longer available, causes compose build to fail. Switched to Open JDK 8. 